### PR TITLE
Add custom allowed browsers option

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
-    
     repositories {
         google()
         jcenter()
-        
     }
+
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.1'
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.3.2.0"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/torusdirect/src/main/java/org/torusresearch/torusdirect/TorusDirectSdk.java
+++ b/torusdirect/src/main/java/org/torusresearch/torusdirect/TorusDirectSdk.java
@@ -60,7 +60,7 @@ public class TorusDirectSdk {
     public CompletableFuture<TorusLoginResponse> triggerLogin(SubVerifierDetails subVerifierDetails) {
         ILoginHandler handler = HandlerFactory.createHandler(new CreateHandlerParams(subVerifierDetails.getClientId(), subVerifierDetails.getVerifier(),
                 this.directSdkArgs.getRedirectUri(), subVerifierDetails.getTypeOfLogin(), this.directSdkArgs.getBrowserRedirectUri(), subVerifierDetails.getJwtParams()));
-        return handler.handleLoginWindow(context, subVerifierDetails.getIsNewActivity(), subVerifierDetails.getPreferCustomTabs())
+        return handler.handleLoginWindow(context, subVerifierDetails.getIsNewActivity(), subVerifierDetails.getPreferCustomTabs(), subVerifierDetails.getAllowedBrowsers())
                 .thenComposeAsync(loginWindowResponse -> handler.getUserInfo(loginWindowResponse).thenApply((userInfo) -> Pair.create(userInfo, loginWindowResponse)))
                 .thenComposeAsync(pair -> {
                     TorusVerifierResponse userInfo = pair.first;
@@ -99,7 +99,7 @@ public class TorusDirectSdk {
                 // Shouldn't open two login windows at once
                 try {
                     // Cannot wait on main thread
-                    LoginWindowResponse resp = handler.handleLoginWindow(context, subVerifierDetails.getIsNewActivity(), subVerifierDetails.getPreferCustomTabs()).join();
+                    LoginWindowResponse resp = handler.handleLoginWindow(context, subVerifierDetails.getIsNewActivity(), subVerifierDetails.getPreferCustomTabs(), subVerifierDetails.getAllowedBrowsers()).join();
                     // Thread safe
                     loginWindowResponses.add(resp);
                 } catch (Exception e) {

--- a/torusdirect/src/main/java/org/torusresearch/torusdirect/handlers/AbstractLoginHandler.java
+++ b/torusdirect/src/main/java/org/torusresearch/torusdirect/handlers/AbstractLoginHandler.java
@@ -79,14 +79,4 @@ public abstract class AbstractLoginHandler implements ILoginHandler {
         context.startActivity(startupIntent);
         return loginWindowResponseCompletableFuture;
     }
-
-    @Override
-    public CompletableFuture<LoginWindowResponse> handleLoginWindow(Context context, boolean isNewActivity, boolean preferCustomTabs) {
-        return this.handleLoginWindow(context, isNewActivity, true, null);
-    }
-
-    @Override
-    public CompletableFuture<LoginWindowResponse> handleLoginWindow(Context context, boolean isNewActivity) {
-        return this.handleLoginWindow(context, isNewActivity, true);
-    }
 }

--- a/torusdirect/src/main/java/org/torusresearch/torusdirect/interfaces/ILoginHandler.java
+++ b/torusdirect/src/main/java/org/torusresearch/torusdirect/interfaces/ILoginHandler.java
@@ -10,8 +10,6 @@ import java8.util.concurrent.CompletableFuture;
 public interface ILoginHandler {
     CompletableFuture<TorusVerifierResponse> getUserInfo(LoginWindowResponse params);
 
-    CompletableFuture<LoginWindowResponse> handleLoginWindow(Context context, boolean isNewActivity);
-    CompletableFuture<LoginWindowResponse> handleLoginWindow(Context context, boolean isNewActivity, boolean preferCustomTabs);
     CompletableFuture<LoginWindowResponse> handleLoginWindow(Context context, boolean isNewActivity, boolean preferCustomTabs, String[] allowedBrowsers);
 
     void setResponse(String response);

--- a/torusdirect/src/main/java/org/torusresearch/torusdirect/interfaces/ILoginHandler.java
+++ b/torusdirect/src/main/java/org/torusresearch/torusdirect/interfaces/ILoginHandler.java
@@ -11,10 +11,12 @@ public interface ILoginHandler {
     CompletableFuture<TorusVerifierResponse> getUserInfo(LoginWindowResponse params);
 
     CompletableFuture<LoginWindowResponse> handleLoginWindow(Context context, boolean isNewActivity);
-
     CompletableFuture<LoginWindowResponse> handleLoginWindow(Context context, boolean isNewActivity, boolean preferCustomTabs);
+    CompletableFuture<LoginWindowResponse> handleLoginWindow(Context context, boolean isNewActivity, boolean preferCustomTabs, String[] allowedBrowsers);
 
     void setResponse(String response);
+
+    void setResponse(Exception exception);
 
     String getFinalURL();
 }

--- a/torusdirect/src/main/java/org/torusresearch/torusdirect/types/NoAllowedBrowserFoundException.java
+++ b/torusdirect/src/main/java/org/torusresearch/torusdirect/types/NoAllowedBrowserFoundException.java
@@ -1,0 +1,7 @@
+package org.torusresearch.torusdirect.types;
+
+public class NoAllowedBrowserFoundException extends Exception {
+    public NoAllowedBrowserFoundException() {
+        super("No allowed browser found.");
+    }
+}

--- a/torusdirect/src/main/java/org/torusresearch/torusdirect/types/SubVerifierDetails.java
+++ b/torusdirect/src/main/java/org/torusresearch/torusdirect/types/SubVerifierDetails.java
@@ -7,6 +7,7 @@ public class SubVerifierDetails {
     private Auth0ClientOptions jwtParams;
     private Boolean isNewActivity;
     private Boolean preferCustomTabs;
+    private String[] allowedBrowsers;
 
     public SubVerifierDetails(LoginType typeOfLogin, String verifier, String clientId, Auth0ClientOptions jwtParams, boolean isNewActivity, boolean preferCustomTabs) {
         this.typeOfLogin = typeOfLogin;
@@ -55,6 +56,13 @@ public class SubVerifierDetails {
 
     public SubVerifierDetails setPreferCustomTabs(boolean val) {
         preferCustomTabs = val;
+        return this;
+    }
+
+    public String[] getAllowedBrowsers() { return allowedBrowsers; }
+
+    public SubVerifierDetails setAllowedBrowsers(String[] val) {
+        allowedBrowsers = val;
         return this;
     }
 }

--- a/torusdirect/src/main/java/org/torusresearch/torusdirect/types/UserCancelledException.java
+++ b/torusdirect/src/main/java/org/torusresearch/torusdirect/types/UserCancelledException.java
@@ -1,0 +1,7 @@
+package org.torusresearch.torusdirect.types;
+
+public class UserCancelledException extends Exception {
+    public UserCancelledException() {
+        super("User cancelled.");
+    }
+}

--- a/torusdirect/src/main/java/org/torusresearch/torusdirect/utils/Helpers.java
+++ b/torusdirect/src/main/java/org/torusresearch/torusdirect/utils/Helpers.java
@@ -2,6 +2,8 @@ package org.torusresearch.torusdirect.utils;
 
 import org.torusresearch.torusdirect.types.JwtUserInfoResult;
 import org.torusresearch.torusdirect.types.LoginType;
+import org.torusresearch.torusdirect.types.NoAllowedBrowserFoundException;
+import org.torusresearch.torusdirect.types.UserCancelledException;
 
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
@@ -10,6 +12,7 @@ import java.util.List;
 import java.util.Objects;
 
 import java8.util.concurrent.CompletableFuture;
+import java8.util.concurrent.CompletionException;
 import java8.util.concurrent.ForkJoinPool;
 
 public class Helpers {
@@ -117,5 +120,19 @@ public class Helpers {
         });
 
         return returnCf;
+    }
+
+    public static Throwable unwrapCompletionException(Throwable error) {
+        Throwable e = error;
+        while (e instanceof CompletionException) e = e.getCause();
+        return e;
+    }
+
+    public static boolean isUserCancelledException(Throwable error) {
+        return (unwrapCompletionException(error) instanceof UserCancelledException);
+    }
+
+    public static boolean isNoAllowedBrowserFoundException(Throwable error) {
+        return (unwrapCompletionException(error) instanceof NoAllowedBrowserFoundException);
     }
 }


### PR DESCRIPTION
Add `allowedBrowsers` option for dev to configure, the same algo as previously applied but will exclude non-allowed browsers if `allowedBrowsers` is provided, throw errors in exception cases instead of just return null.