### PR TITLE
Fix Jitpack using incorrect JDK

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
This fixes issue that Jitpack won't build because it's using incompatible JDK with latest Gradle (7).

Reference:
https://stackoverflow.com/questions/69276973/android-gradle-plugin-requires-java-11-to-run-while-publishing-jitpack-library
https://jitpack.io/docs/BUILDING/#java-version