### PR TITLE
Fix deprecated Maven plugin being used by Jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,4 @@
 jdk:
   - openjdk11
+install:
+  - ./gradlew :sdk:build :sdk:publishToMavenLocal

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'maven-publish'
 }
 
 android {
@@ -45,4 +46,14 @@ dependencies {
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+            }
+        }
+    }
 }


### PR DESCRIPTION
Jitpack default to uses a deprecated maven plugin which causes building process to fail. This specifies the latest maven plugin for publishing. The issue was fixed and tested.